### PR TITLE
Auth Reverse Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+roomie-gateway
+tmp/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # roomie-gateway
+The API gateway service for the roomie app
+
+## auth
+`/auth` routes are reverse proxied to `$AUTH_UPSTREAM`

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Setup the router
 	mux := powermux.NewServeMux()
-	mux.Route(ROUTE_AUTH + "/*").Any(authGateway)
+	mux.Route(ROUTE_AUTH).Any(authGateway).Route("*").Any(authGateway)
 
 	// Run the server
 	port := os.Getenv(CONF_PORT)

--- a/main.go
+++ b/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/andrewburian/powermux"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"github.com/Sirupsen/logrus"
+	"net/http"
+)
+
+const (
+	ROUTE_AUTH = "auth"
+)
+
+func main() {
+
+	// Logger
+	logger := logrus.StandardLogger()
+
+	// The auth gateway
+	var authGateway *httputil.ReverseProxy
+	{
+		authUpstreamPath := os.Getenv("AUTH_UPSTREAM")
+		authUpstream, err := url.Parse(authUpstreamPath)
+		if err != nil {
+			logger.WithField("auth_upstream", authUpstreamPath).Fatal("Invalid Auth Upstream")
+		}
+		authGateway = httputil.NewSingleHostReverseProxy(authUpstream)
+	}
+
+
+	// Setup the router
+	mux := powermux.NewServeMux()
+	mux.Route(ROUTE_AUTH).Any(authGateway)
+
+	// Run the server
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "http"
+	}
+	err := http.ListenAndServe(":"+port, mux)
+	logger.Fatal(err)
+
+}

--- a/main.go
+++ b/main.go
@@ -1,16 +1,21 @@
 package main
 
 import (
+	"github.com/Sirupsen/logrus"
 	"github.com/andrewburian/powermux"
+	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"github.com/Sirupsen/logrus"
-	"net/http"
 )
 
 const (
 	ROUTE_AUTH = "auth"
+)
+
+const (
+	CONF_PORT          = "PORT"
+	CONF_AUTH_UPSTREAM = "AUTH_UPSTREAM"
 )
 
 func main() {
@@ -21,21 +26,20 @@ func main() {
 	// The auth gateway
 	var authGateway *httputil.ReverseProxy
 	{
-		authUpstreamPath := os.Getenv("AUTH_UPSTREAM")
+		authUpstreamPath := os.Getenv(CONF_AUTH_UPSTREAM)
 		authUpstream, err := url.Parse(authUpstreamPath)
 		if err != nil {
-			logger.WithField("auth_upstream", authUpstreamPath).Fatal("Invalid Auth Upstream")
+			logger.WithField(CONF_AUTH_UPSTREAM, authUpstreamPath).Fatal("Invalid Auth Upstream")
 		}
 		authGateway = httputil.NewSingleHostReverseProxy(authUpstream)
 	}
-
 
 	// Setup the router
 	mux := powermux.NewServeMux()
 	mux.Route(ROUTE_AUTH).Any(authGateway)
 
 	// Run the server
-	port := os.Getenv("PORT")
+	port := os.Getenv(CONF_PORT)
 	if port == "" {
 		port = "http"
 	}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Setup the router
 	mux := powermux.NewServeMux()
-	mux.Route(ROUTE_AUTH).Any(authGateway)
+	mux.Route(ROUTE_AUTH + "/*").Any(authGateway)
 
 	// Run the server
 	port := os.Getenv(CONF_PORT)


### PR DESCRIPTION
Super simple start to the gateway, a blind reverse proxy to the auth service for any traffic that comes to an `/auth/*` endpoint.

PORT is configured by env variable as a requirement for Heroku
AUTH_UPSTREAM is for convenient configuration between different environments

@gdabu @tratnayake 