### PR TITLE
Replaced proxy director with custom director

### DIFF
--- a/director.go
+++ b/director.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// NewHostReverseProxy is a copy of httputil.NewSingleHostReverseProxy
+// with the only modification being that req.Host is also set
+func NewHostReverseProxy(target *url.URL) *httputil.ReverseProxy {
+	targetQuery := target.RawQuery
+	director := func(req *http.Request) {
+		req.Host = target.Host
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+	return &httputil.ReverseProxy{Director: director}
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		if err != nil {
 			logger.WithField(CONF_AUTH_UPSTREAM, authUpstreamPath).Fatal("Invalid Auth Upstream")
 		}
-		authGateway = httputil.NewSingleHostReverseProxy(authUpstream)
+		authGateway = NewHostReverseProxy(authUpstream)
 	}
 
 	// Setup the router


### PR DESCRIPTION
Heroku requires that `req.Host` is set to route the request to the correct upstream dyno. So we set this field with a custom director.